### PR TITLE
Delete DormantDatabase while resuming

### DIFF
--- a/pkg/eventer/event_recorder.go
+++ b/pkg/eventer/event_recorder.go
@@ -26,6 +26,7 @@ const (
 	EventReasonInitializing         string = "Initializing"
 	EventReasonInvalid              string = "Invalid"
 	EventReasonInvalidUpdate        string = "InvalidUpdate"
+	EventReasonResuming             string = "Resuming"
 	EventReasonSnapshotFailed       string = "SnapshotFailed"
 	EventReasonStarting             string = "Starting"
 	EventReasonSuccessfulCreate     string = "SuccessfulCreate"


### PR DESCRIPTION
While resuming a paused database, delete DormantDatabase object first. 
Then create Original Database object.

This ensures that either Original DB or Dormant DB will exist.

Fix Issue: [k8sdb/operator/#14](https://github.com/k8sdb/operator/issues/14)